### PR TITLE
Update options.php

### DIFF
--- a/classes/options.php
+++ b/classes/options.php
@@ -56,12 +56,14 @@ class Simpleresponsiveslider_Options {
      * @return void
      */
     public function add_page() {
-        add_theme_page(
+        add_menu_page(
             $this->page_title,
             $this->page_title,
             $this->capability,
             $this->slug,
-            array( &$this, 'settings_page' )
+            array( &$this, 'settings_page' ),
+            'dashicons-admin-generic',
+            35
         );
     }
 


### PR DESCRIPTION
Changing the capability so that editors and admins can see the slider options. Not all clients want to see all of the site editing options, so this gives a good way to give most privileges, while restricting the technically sensitive ones.
